### PR TITLE
Fix timeout issue with test steps in workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         uv sync --dev
     - name: Locate bobcat pre-trained model cache
       id: loc-bobcat-cache
-      run: echo "dir=$(python -c 'from lambeq.text2diagram.model_downloader import ModelDownloader; print(ModelDownloader("bert").model_dir)')" >> $GITHUB_OUTPUT
+      run: echo "dir=$(echo 'from lambeq.text2diagram.model_downloader import ModelDownloader; print(ModelDownloader("bert").model_dir)' | uv run - )" >> $GITHUB_OUTPUT
     - name: Restore bobcat pre-trained model from cache
       id: bobcat-cache
       uses: actions/cache@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,14 +44,17 @@ jobs:
         sudo apt-get install graphviz pandoc
         uv sync --dev
     - name: Test example notebooks
-      run: >
-        TEST_NOTEBOOKS=1 uv run pytest --nbmake ${{ env.DOCS_DIR }}/examples/
-        --nbmake-timeout=60
+      env:
+        TEST_NOTEBOOKS: 1
+      run: |
+        echo $TEST_NOTEBOOKS
+        uv run pytest --nbmake ${{ env.DOCS_DIR }}/examples/ --nbmake-timeout=60
     - name: Test tutorial notebooks
-      run: >
-        TEST_NOTEBOOKS=1 uv run pytest --nbmake ${{ env.DOCS_DIR }}/tutorials/
-        --nbmake-timeout=60
-        --ignore ${{ env.DOCS_DIR }}/tutorials/code
+      env:
+        TEST_NOTEBOOKS: 1
+      run: |
+        echo $TEST_NOTEBOOKS
+        uv run pytest --nbmake ${{ env.DOCS_DIR }}/tutorials/ --nbmake-timeout=60 --ignore ${{ env.DOCS_DIR }}/tutorials/code
     - name: Clean notebooks
       run: |
         uv run scripts/clean_notebooks.py -p ${{ env.DOCS_DIR }} -s

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,14 +57,14 @@ jobs:
         TEST_NOTEBOOKS: 1
       run: >
         uv run pytest --nbmake ${{ env.DOCS_DIR }}/examples/
-          --nbmake-timeout=60
+        --nbmake-timeout=60
     - name: Test tutorial notebooks
       env:
         TEST_NOTEBOOKS: 1
       run: >
         uv run pytest --nbmake ${{ env.DOCS_DIR }}/tutorials/
-          --nbmake-timeout=60
-          --ignore ${{ env.DOCS_DIR }}/tutorials/code
+        --nbmake-timeout=60
+        --ignore ${{ env.DOCS_DIR }}/tutorials/code
     - name: Clean notebooks
       run: |
         uv run scripts/clean_notebooks.py -p ${{ env.DOCS_DIR }} -s

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,16 +44,12 @@ jobs:
         sudo apt-get install graphviz pandoc
         uv sync --dev
     - name: Test example notebooks
-      env:
-        TEST_NOTEBOOKS: 1
       run: >
-        uv run pytest --nbmake ${{ env.DOCS_DIR }}/examples/
+        TEST_NOTEBOOKS=1 uv run pytest --nbmake ${{ env.DOCS_DIR }}/examples/
         --nbmake-timeout=60
     - name: Test tutorial notebooks
-      env:
-        TEST_NOTEBOOKS: 1
       run: >
-        uv run pytest --nbmake ${{ env.DOCS_DIR }}/tutorials/
+        TEST_NOTEBOOKS=1 uv run pytest --nbmake ${{ env.DOCS_DIR }}/tutorials/
         --nbmake-timeout=60
         --ignore ${{ env.DOCS_DIR }}/tutorials/code
     - name: Clean notebooks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,18 +43,28 @@ jobs:
       run: |
         sudo apt-get install graphviz pandoc
         uv sync --dev
+    - name: Locate bobcat pre-trained model cache
+      id: loc-bobcat-cache
+      run: echo "dir=$(python -c 'from lambeq.text2diagram.model_downloader import ModelDownloader; print(ModelDownloader("bert").model_dir)')" >> $GITHUB_OUTPUT
+    - name: Restore bobcat pre-trained model from cache
+      id: bobcat-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.loc-bobcat-cache.outputs.dir }}
+        key: bobcat-bert-v1
     - name: Test example notebooks
       env:
         TEST_NOTEBOOKS: 1
-      run: |
-        echo $TEST_NOTEBOOKS
-        uv run pytest --nbmake ${{ env.DOCS_DIR }}/examples/ --nbmake-timeout=60
+      run: >
+        uv run pytest --nbmake ${{ env.DOCS_DIR }}/examples/
+          --nbmake-timeout=60
     - name: Test tutorial notebooks
       env:
         TEST_NOTEBOOKS: 1
-      run: |
-        echo $TEST_NOTEBOOKS
-        uv run pytest --nbmake ${{ env.DOCS_DIR }}/tutorials/ --nbmake-timeout=60 --ignore ${{ env.DOCS_DIR }}/tutorials/code
+      run: >
+        uv run pytest --nbmake ${{ env.DOCS_DIR }}/tutorials/
+          --nbmake-timeout=60
+          --ignore ${{ env.DOCS_DIR }}/tutorials/code
     - name: Clean notebooks
       run: |
         uv run scripts/clean_notebooks.py -p ${{ env.DOCS_DIR }} -s


### PR DESCRIPTION
The tests fail due to timeout issues during the initial download of the Bobcat model.