### PR TITLE
Update `BASE_PATH` for GH page deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,15 +73,9 @@ jobs:
       with:
         args: '-v -DPLANTUML_LIMIT_SIZE=8192 -tpng ${{ env.DOCS_DIR }}/puml/*.puml -o img'
     - name: Build documentation
-      run: BASE_PATH="/lambeq" uv run ./build-docs.sh
-    - name: Setup pages
-      id: pages
-      uses: actions/configure-pages@v3
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
-      with:
-        # upload build output
-        path: ${{ env.DOCS_BUILD_DIR }}
+      env:
+        BASE_PATH: '/lambeq'
+      run: uv run ./build-docs.sh
     - name: Zip up documentation to store as release asset
       if: ${{ github.event_name == 'release' }}
       run: |
@@ -101,6 +95,18 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
     steps:
+    - name: Build documentation
+      env:
+        BASE_PATH: '/lambeq-docs'
+      run: uv run ./build-docs.sh
+    - name: Setup pages
+      id: pages
+      uses: actions/configure-pages@v3
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v2
+      with:
+        # upload build output
+        path: ${{ env.DOCS_BUILD_DIR }}
     - name: Deploy artifact
       id: deployment
       uses: actions/deploy-pages@v2


### PR DESCRIPTION
The `BASE_PATH` for the GH page deployment should be `/lambeq-docs`, otherwise the static assets will not be fetched properly. In addition, the build and artifact creation steps have been moved to the deployment job since creating the tarball for the unified docs requires a different `BASE_PATH` and is independent from the GH page.